### PR TITLE
Fix: Set WelcomeScreen as initial route

### DIFF
--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -19,7 +19,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 // Import screen components. Ensure these paths are correct and screens exist.
 // The WelcomeScreen.tsx is assumed to exist from the initial project structure.
 // LoginScreen and SignupScreen would be new screens for authentication.
-// import WelcomeScreen from '../screens/WelcomeScreen'; 
+import WelcomeScreen from '../screens/WelcomeScreen'; 
 // import LoginScreen from '../screens/LoginScreen'; // To be created
 // import SignupScreen from '../screens/SignupScreen'; // To be created
 
@@ -43,12 +43,13 @@ const AuthNavigator: React.FC = () => {
     >
       {/* 
       Example Screens (actual components need to be imported and working):
-
+      */}
       <Stack.Screen 
         name="Welcome" 
         component={WelcomeScreen} 
         // options={{ headerShown: false }} // Example: hide header for welcome screen
       />
+      {/*
       <Stack.Screen 
         name="Login" 
         component={LoginScreen} // Replace with actual LoginScreen component

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -22,7 +22,7 @@ const RootNavigator: React.FC = () => {
   // Simulate authentication state - replace with actual auth logic from store/context later
   // Defaulting to true allows direct testing of AppNavigator and its screens.
   // Set to false to test AuthNavigator.
-  const [isAuthenticated, setIsAuthenticated] = useState(true); 
+  const [isAuthenticated, setIsAuthenticated] = useState(false); 
 
   // Example of how you might integrate with a global state or async storage for auth:
   // const { user, isLoadingAuth } = useAuth(); // Assuming useAuth() provides user and loading state


### PR DESCRIPTION
This commit addresses the issue where the main screen was missing and the first screen was not a login screen.

Changes made:
- Modified `RootNavigator.tsx` to default `isAuthenticated` to `false`, ensuring `AuthNavigator` is shown first.
- Modified `AuthNavigator.tsx` to uncomment the `WelcomeScreen` import and its `Stack.Screen` definition, making it the initial screen.
- Confirmed that CSS styles remain in `WelcomeScreen.tsx` as per common React Native practice.

The application will now start with the `WelcomeScreen`, allowing you to see login options as the first view.