### PR TITLE
feat: Attempt to add logout to SettingsScreen; blocked by an issue

### DIFF
--- a/src/screens/CommunityFeedScreen.tsx
+++ b/src/screens/CommunityFeedScreen.tsx
@@ -1,8 +1,9 @@
 // src/screens/CommunityFeedScreen.tsx
 
 import React from 'react';
-import { View, Text, StyleSheet, FlatList, useColorScheme, Image, TouchableOpacity } from 'react-native'; // useColorScheme, Image, TouchableOpacity 추가
+import { View, Text, StyleSheet, FlatList, useColorScheme, Image, TouchableOpacity } from 'react-native';
 import { Colors } from '../constants/Colors'; // Colors 임포트
+import CustomAppBar from '../../components/organisms/CustomAppBar'; // CustomAppBar 임포트
 
 /**
  * @file CommunityFeedScreen.tsx
@@ -54,8 +55,8 @@ const CommunityFeedScreen: React.FC<CommunityFeedScreenProps> = (props) => {
 
   const renderFeedItem = ({ item }: { item: FeedItem }) => (
     <TouchableOpacity
-      style={[styles.feedItem, { backgroundColor: currentColors.cardBackground }]}
-      onPress={() => props.onSelectRecipe?.(item.id)} // 레시피 상세 화면으로 이동 (가정)
+      style={[styles.feedItem, { backgroundColor: currentColors.cardBackground, shadowColor: currentColors.text }]} // Added shadowColor based on theme
+      onPress={() => props.onSelectRecipe?.(item.id)}
     >
       <View style={styles.feedItemHeader}>
         {item.userAvatarUrl && <Image source={{ uri: item.userAvatarUrl }} style={styles.avatar} />}
@@ -70,8 +71,7 @@ const CommunityFeedScreen: React.FC<CommunityFeedScreenProps> = (props) => {
           좋아요: {item.likes}  댓글: {item.commentsCount}
         </Text>
       </View>
-      {/* 좋아요/댓글 버튼, 이미지 등을 위한 향후 UI 요소 */}
-      <View style={styles.feedItemActions}>
+      <View style={[styles.feedItemActions, { borderTopColor: currentColors.borderColor }]}> {/* Themed borderTopColor */}
         <TouchableOpacity style={styles.actionButton}>
           <Text style={[styles.actionText, {color: currentColors.primary}]}>👍 좋아요</Text>
         </TouchableOpacity>
@@ -84,13 +84,16 @@ const CommunityFeedScreen: React.FC<CommunityFeedScreenProps> = (props) => {
 
   return (
     <View style={[styles.container, { backgroundColor: currentColors.background }]}>
+      <CustomAppBar title="커뮤니티" />
+      {/* 기존 title Text는 CustomAppBar로 대체되었으므로 삭제
       <Text style={[styles.title, { color: currentColors.text }]}>커뮤니티 피드</Text>
+      */}
       <FlatList
         data={feedItems}
         keyExtractor={(item) => item.id}
         renderItem={renderFeedItem}
-        ItemSeparatorComponent={() => <View style={{ height: 12, backgroundColor: currentColors.background }} />} // 아이템 간 간격
-        contentContainerStyle={{ paddingBottom: 16 }} // 하단 패딩 추가
+        ItemSeparatorComponent={() => <View style={{ height: 12, backgroundColor: currentColors.background }} />}
+        contentContainerStyle={styles.listContentContainer} // Changed from paddingBottom to this
       />
     </View>
   );
@@ -99,22 +102,26 @@ const CommunityFeedScreen: React.FC<CommunityFeedScreenProps> = (props) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    // backgroundColor는 컴포넌트에서 동적으로 설정
   },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 16,
-    paddingHorizontal: 16, // 타이틀에도 패딩 적용
-    paddingTop: 16,
-    // color는 컴포넌트에서 동적으로 설정
+  // title 스타일은 CustomAppBar로 대체되었으므로 삭제
+  // title: {
+  //   fontSize: 24,
+  //   fontWeight: 'bold',
+  //   marginBottom: 16,
+  //   paddingHorizontal: 16,
+  //   paddingTop: 16,
+  // },
+  listContentContainer: { // FlatList에 대한 패딩
+    paddingHorizontal: 16, // 좌우 마진 대신 FlatList 내부 패딩으로 변경
+    paddingTop: 16, // CustomAppBar와의 간격
+    paddingBottom: 16, // 하단 여백
   },
   feedItem: {
-    borderRadius: 12, // 모서리 둥글게
-    marginHorizontal: 16, // 좌우 마진
-    overflow: 'hidden', // 이미지 등 내용이 넘치지 않도록
-    elevation: 2, // 안드로이드 그림자
-    shadowColor: '#000000', // iOS 그림자
+    borderRadius: 12,
+    // marginHorizontal: 16, // FlatList 패딩으로 대체
+    overflow: 'hidden',
+    elevation: 2,
+    // shadowColor 는 컴포넌트에서 동적으로 설정
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.1,
     shadowRadius: 3,
@@ -129,16 +136,16 @@ const styles = StyleSheet.create({
     height: 40,
     borderRadius: 20,
     marginRight: 10,
-    backgroundColor: '#E0E0E0', // 이미지 없을 시 배경색
+    backgroundColor: '#E0E0E0',
   },
   userName: {
     fontSize: 16,
-    fontWeight: '600', // semibold
+    fontWeight: '600',
   },
   recipeImage: {
     width: '100%',
-    height: 250, // 이미지 높이 조절
-    backgroundColor: '#E0E0E0', // 이미지 없을 시 배경색
+    height: 250,
+    backgroundColor: '#E0E0E0',
   },
   feedItemContent: {
     padding: 12,
@@ -148,15 +155,15 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: 6,
   },
-  feedItemStats: { // 좋아요, 댓글 수 텍스트 스타일
+  feedItemStats: {
     fontSize: 14,
   },
   feedItemActions: {
     flexDirection: 'row',
     justifyContent: 'space-around',
     paddingVertical: 8,
-    borderTopWidth: 1,
-    // borderTopColor는 ItemSeparatorComponent 사용 시 필요 없을 수 있으나, 카드 내부 구분선으로 사용
+    borderTopWidth: StyleSheet.hairlineWidth, // 더 얇은 선
+    // borderTopColor는 컴포넌트에서 동적으로 설정
   },
   actionButton: {
     padding: 8,

--- a/src/screens/RecipeDetailScreen.tsx
+++ b/src/screens/RecipeDetailScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { useRoute, RouteProp } from '@react-navigation/native';
 import { HomeStackParamList } from '../navigation/AppNavigator'; // Adjust path if needed
 import { Colors } from '../constants/Colors'; // Adjust path if needed
+import CustomAppBar from '../../components/organisms/CustomAppBar'; // CustomAppBar 임포트
 
 // 상세 레시피 정보를 위한 목업 데이터
 const detailedMockRecipes = [
@@ -103,108 +104,117 @@ const RecipeDetailScreen: React.FC = () => {
 
   if (!recipe) {
     return (
-      <View style={[styles.container, styles.centered, { backgroundColor: currentColors.background }]}>
-        <Text style={[styles.errorText, { color: currentColors.text }]}>레시피를 찾을 수 없습니다.</Text>
+      <View style={{flex: 1, backgroundColor: currentColors.background }}>
+        <CustomAppBar title="레시피 정보 없음" showBackButton={true} />
+        <View style={[styles.container, styles.centered]}>
+          <Text style={[styles.errorText, { color: currentColors.text }]}>레시피를 찾을 수 없습니다.</Text>
+        </View>
       </View>
     );
   }
 
   return (
-    <ScrollView style={[styles.container, { backgroundColor: currentColors.background }]}>
-      {recipe.image && (
-        <Image source={{ uri: recipe.image }} style={styles.recipeImage} resizeMode="cover" />
-      )}
-      <View style={styles.contentContainer}>
-        <Text style={[styles.title, { color: currentColors.text }]}>{recipe.name}</Text>
+    <View style={{ flex: 1, backgroundColor: currentColors.background }}>
+      <CustomAppBar title={recipe.name} showBackButton={true} />
+      <ScrollView style={styles.container}>
+        {recipe.image && (
+          <Image source={{ uri: recipe.image }} style={styles.recipeImage} resizeMode="cover" />
+        )}
+        <View style={styles.contentContainer}>
+          {/* 기존 recipe.name Text는 CustomAppBar의 title로 대체되었으므로 삭제
+          <Text style={[styles.title, { color: currentColors.text }]}>{recipe.name}</Text>
+          */}
 
-        <View style={styles.metaSection}>
-          <Text style={[styles.metaText, { color: currentColors.placeholderText }]}>조리 시간: {recipe.cookingTime}</Text>
-          <Text style={[styles.metaText, { color: currentColors.placeholderText }]}>난이도: {recipe.difficulty}</Text>
-        </View>
-         <Text style={[styles.metaText, { color: currentColors.placeholderText, marginBottom: 20 }]}>칼로리: {recipe.nutritionalInfo.calories}</Text>
-
-
-        <Text style={[styles.sectionTitle, { color: currentColors.primary }]}>재료</Text>
-        {recipe.ingredients.map((ingredient, index) => (
-          <View key={index} style={styles.listItem}>
-            <Text style={[styles.listItemText, { color: currentColors.text }]}>{ingredient.name}</Text>
-            <Text style={[styles.listItemAmount, { color: currentColors.placeholderText }]}>{ingredient.amount}</Text>
+          <View style={styles.metaSection}>
+            <Text style={[styles.metaText, { color: currentColors.placeholderText }]}>조리 시간: {recipe.cookingTime}</Text>
+            <Text style={[styles.metaText, { color: currentColors.placeholderText }]}>난이도: {recipe.difficulty}</Text>
           </View>
-        ))}
+          <Text style={[styles.metaText, { color: currentColors.placeholderText, marginBottom: 20 }]}>칼로리: {recipe.nutritionalInfo.calories}</Text>
 
-        <Text style={[styles.sectionTitle, { color: currentColors.primary, marginTop: 20 }]}>조리 방법</Text>
-        {recipe.instructions.map((instruction, index) => (
-          <Text key={index} style={[styles.instructionText, { color: currentColors.text }]}>
-            {`${index + 1}. ${instruction}`}
-          </Text>
-        ))}
+          <Text style={[styles.sectionTitle, { color: currentColors.primary }]}>재료</Text>
+          {recipe.ingredients.map((ingredient, index) => (
+            <View key={index} style={[styles.listItem, { borderBottomColor: currentColors.borderColor }]}>
+              <Text style={[styles.listItemText, { color: currentColors.text }]}>{ingredient.name}</Text>
+              <Text style={[styles.listItemAmount, { color: currentColors.placeholderText }]}>{ingredient.amount}</Text>
+            </View>
+          ))}
 
-        <Text style={[styles.sectionTitle, { color: currentColors.primary, marginTop: 20 }]}>영양 정보</Text>
-        <Text style={[styles.infoText, { color: currentColors.text }]}>칼로리: {recipe.nutritionalInfo.calories}</Text>
-        <Text style={[styles.infoText, { color: currentColors.text }]}>단백질: {recipe.nutritionalInfo.protein}</Text>
-        <Text style={[styles.infoText, { color: currentColors.text }]}>탄수화물: {recipe.nutritionalInfo.carbs}</Text>
-        <Text style={[styles.infoText, { color: currentColors.text }]}>지방: {recipe.nutritionalInfo.fat}</Text>
-      </View>
-    </ScrollView>
+          <Text style={[styles.sectionTitle, { color: currentColors.primary, marginTop: 20 }]}>조리 방법</Text>
+          {recipe.instructions.map((instruction, index) => (
+            <Text key={index} style={[styles.instructionText, { color: currentColors.text }]}>
+              {`${index + 1}. ${instruction}`}
+            </Text>
+          ))}
+
+          <Text style={[styles.sectionTitle, { color: currentColors.primary, marginTop: 20 }]}>영양 정보</Text>
+          <Text style={[styles.infoText, { color: currentColors.text }]}>칼로리: {recipe.nutritionalInfo.calories}</Text>
+          <Text style={[styles.infoText, { color: currentColors.text }]}>단백질: {recipe.nutritionalInfo.protein}</Text>
+          <Text style={[styles.infoText, { color: currentColors.text }]}>탄수화물: {recipe.nutritionalInfo.carbs}</Text>
+          <Text style={[styles.infoText, { color: currentColors.text }]}>지방: {recipe.nutritionalInfo.fat}</Text>
+        </View>
+      </ScrollView>
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
+  container: { // 이제 ScrollView 또는 오류 시 View의 스타일이 됨
     flex: 1,
   },
-  centered: {
+  centered: { // 오류 메시지 중앙 정렬을 위해 유지
     justifyContent: 'center',
     alignItems: 'center',
   },
   recipeImage: {
     width: '100%',
-    height: Dimensions.get('window').width * 0.7, // 이미지 높이를 화면 너비의 70%로 설정
-    backgroundColor: '#e0e0e0',
+    height: Dimensions.get('window').width * 0.7,
+    backgroundColor: '#e0e0e0', // 이미지 로딩 중 배경색
   },
   contentContainer: {
     padding: 20,
   },
-  title: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    marginBottom: 12,
-    textAlign: 'center',
-  },
+  // title 스타일은 CustomAppBar로 대체되었으므로 삭제
+  // title: {
+  //   fontSize: 28,
+  //   fontWeight: 'bold',
+  //   marginBottom: 12,
+  //   textAlign: 'center',
+  // },
   metaSection: {
     flexDirection: 'row',
     justifyContent: 'space-around',
     marginBottom: 8,
+    marginTop: 8, // 이미지와 제목 사이 간격 (제목이 AppBar로 이동했으므로 이미지 바로 아래 메타 정보)
   },
   metaText: {
     fontSize: 15,
   },
   sectionTitle: {
     fontSize: 22,
-    fontWeight: '600', // semibold
-    marginTop: 10,
+    fontWeight: '600',
+    marginTop: 10, // 이전 제목과의 간격 유지 또는 조정
     marginBottom: 12,
   },
   listItem: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    paddingVertical: 8,
-    borderBottomWidth: 1,
-    borderBottomColor: '#eee', // 테마 색상 currentColors.borderColor로 변경 가능
+    paddingVertical: 10, // 패딩 증가
+    borderBottomWidth: StyleSheet.hairlineWidth, // 더 얇은 구분선
+    // borderBottomColor는 컴포넌트에서 동적으로 설정
   },
   listItemText: {
     fontSize: 16,
-    flex: 1, // 이름이 길 경우 공간 차지
+    flex: 1,
   },
   listItemAmount: {
     fontSize: 16,
   },
   instructionText: {
     fontSize: 16,
-    lineHeight: 24,
-    marginBottom: 8,
+    lineHeight: 26, // 줄 간격 증가
+    marginBottom: 10, // 각 단계 사이 간격 증가
   },
-  infoText: { // 영양 정보 등 일반 텍스트
+  infoText: {
     fontSize: 16,
     lineHeight: 22,
     marginBottom: 4,

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View, useColorScheme } from 'react-native';
 import { Colors } from '../constants/Colors'; // Colors 임포트
+import CustomAppBar from '../../components/organisms/CustomAppBar'; // CustomAppBar 임포트
 
 // 카테고리 목록 (한국어)
 const categories = [
@@ -28,129 +29,116 @@ const SearchScreen: React.FC = () => {
   const currentColors = Colors[colorScheme];
 
   return (
-    <ScrollView
-      style={[styles.container, { backgroundColor: currentColors.background }]}
-      showsVerticalScrollIndicator={false}
-      keyboardShouldPersistTaps="handled" // 검색창 입력 중 다른 곳 탭 시 키보드 숨김
-    >
-      {/* 헤더 */}
-      <View style={styles.header}>
-        <Text style={[styles.headerTitle, { color: currentColors.text }]}>검색</Text>
-      </View>
+    <View style={{ flex: 1, backgroundColor: currentColors.background }}>
+      <CustomAppBar title="레시피 검색" />
+      <ScrollView
+        style={styles.scrollViewContainer} // Renamed from styles.container to avoid conflict if any
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* 기존 헤더 View는 CustomAppBar로 대체되었으므로 삭제됨
+        <View style={styles.header}>
+          <Text style={[styles.headerTitle, { color: currentColors.text }]}>검색</Text>
+        </View>
+        */}
 
-      {/* 검색창 */}
-      <View style={[styles.searchContainer, { backgroundColor: currentColors.cardBackground, borderColor: currentColors.borderColor }]}>
-        <Text style={[styles.searchIcon, { color: currentColors.placeholderText }]}>🔍</Text>
-        <TextInput
-          style={[styles.searchInput, { color: currentColors.text }]}
-          placeholder="레시피 검색..."
-          placeholderTextColor={currentColors.placeholderText}
-        />
-      </View>
+        {/* 검색창 */}
+        <View style={[styles.searchContainer, { backgroundColor: currentColors.cardBackground, borderColor: currentColors.borderColor }]}>
+          <Text style={[styles.searchIcon, { color: currentColors.placeholderText }]}>🔍</Text>
+          <TextInput
+            style={[styles.searchInput, { color: currentColors.text }]}
+            placeholder="레시피 검색..."
+            placeholderTextColor={currentColors.placeholderText}
+          />
+        </View>
 
-      {/* 카테고리 */}
-      <Text style={[styles.sectionTitle, { color: currentColors.text }]}>카테고리</Text>
-      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.categoriesContainer}>
-        {categories.map((category: string, index: number) => (
-          <TouchableOpacity key={index} style={[styles.categoryItem, { backgroundColor: currentColors.cardBackground }]}>
-            <Text style={[styles.categoryText, { color: currentColors.text }]}>{category}</Text>
-          </TouchableOpacity>
-        ))}
+        {/* 카테고리 */}
+        <Text style={[styles.sectionTitle, { color: currentColors.text }]}>카테고리</Text>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.categoriesContainer}>
+          {categories.map((category: string, index: number) => (
+            <TouchableOpacity key={index} style={[styles.categoryItem, { backgroundColor: currentColors.cardBackground }]}>
+              <Text style={[styles.categoryText, { color: currentColors.text }]}>{category}</Text>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+
+        {/* 최근 검색어 */}
+        <Text style={[styles.sectionTitle, { color: currentColors.text }]}>최근 검색어</Text>
+        <View style={styles.recentSearchesContainer}>
+          {recentSearches.map((search: string, index: number) => (
+            <TouchableOpacity key={index} style={[styles.recentSearchItem, { borderBottomColor: currentColors.borderColor }]}>
+              <Text style={[styles.recentSearchText, { color: currentColors.text }]}>{search}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+        <View style={{height: 20}} />{/* Add some bottom padding */}
       </ScrollView>
-
-      {/* 최근 검색어 */}
-      <Text style={[styles.sectionTitle, { color: currentColors.text }]}>최근 검색어</Text>
-      <View style={styles.recentSearchesContainer}>
-        {recentSearches.map((search: string, index: number) => (
-          <TouchableOpacity key={index} style={[styles.recentSearchItem, { borderBottomColor: currentColors.borderColor }]}>
-            <Text style={[styles.recentSearchText, { color: currentColors.text }]}>{search}</Text>
-          </TouchableOpacity>
-        ))}
-      </View>
-    </ScrollView>
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
+  scrollViewContainer: { // Was styles.container, renamed for clarity
     flex: 1,
-    // backgroundColor는 컴포넌트에서 동적으로 설정
   },
-  header: {
-    paddingHorizontal: 16,
-    paddingTop: 24, // 상태 표시줄 고려
-    paddingBottom: 8,
-    alignItems: 'center', // 중앙 정렬
-  },
-  headerTitle: {
-    fontSize: 22, // 크기 약간 증가
-    fontWeight: 'bold',
-    // color는 컴포넌트에서 동적으로 설정
-  },
+  // header 및 headerTitle 스타일은 CustomAppBar로 대체되어 삭제
   sectionTitle: {
     fontSize: 20,
-    fontWeight: '600', // semibold 대신
-    // color는 컴포넌트에서 동적으로 설정
+    fontWeight: '600',
     paddingHorizontal: 16,
-    marginTop: 24, // 섹션 간 간격
-    marginBottom: 8,
+    marginTop: 24,
+    marginBottom: 12, // 늘림
   },
   searchContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginHorizontal: 16, // 좌우 마진
-    paddingHorizontal: 12, // 내부 패딩
-    borderRadius: 12, // 모서리 둥글게
+    marginHorizontal: 16,
+    marginTop: 16, // CustomAppBar 아래에 간격 추가
+    paddingHorizontal: 12,
+    borderRadius: 12,
     borderWidth: 1,
-    // backgroundColor, borderColor는 컴포넌트에서 동적으로 설정
-    height: 48, // 높이 고정
+    height: 48,
   },
   searchIcon: {
     fontSize: 20,
-    // color는 컴포넌트에서 동적으로 설정
-    marginRight: 8, // 아이콘과 텍스트 입력창 간격
+    marginRight: 8,
   },
   searchInput: {
     flex: 1,
     fontSize: 16,
-    // color는 컴포넌트에서 동적으로 설정
-    height: '100%', // 부모 높이 채우기
+    height: '100%',
   },
   categoriesContainer: {
-    paddingHorizontal: 16, // 좌우 패딩
-    paddingVertical: 8, // 상하 패딩
+    paddingHorizontal: 16,
+    paddingVertical: 8,
   },
   categoryItem: {
-    paddingVertical: 10, // 상하 패딩
-    paddingHorizontal: 16, // 좌우 패딩
-    borderRadius: 20, // 타원형 모양
-    marginRight: 10, // 아이템 간 간격
-    // backgroundColor는 컴포넌트에서 동적으로 설정
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+    marginRight: 10,
     alignItems: 'center',
     justifyContent: 'center',
-    elevation: 1, // 안드로이드 그림자
-    shadowColor: '#000', // iOS 그림자
+    elevation: 1,
+    shadowColor: '#000',
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.1,
     shadowRadius: 2,
   },
   categoryText: {
-    fontSize: 15, // 폰트 크기 조절
+    fontSize: 15,
     fontWeight: '500',
-    // color는 컴포넌트에서 동적으로 설정
   },
   recentSearchesContainer: {
     paddingHorizontal: 16,
     marginTop: 8,
   },
   recentSearchItem: {
-    paddingVertical: 12, // 상하 패딩 증가
-    borderBottomWidth: 1,
-    // borderBottomColor는 컴포넌트에서 동적으로 설정
+    paddingVertical: 14, // 늘림
+    borderBottomWidth: StyleSheet.hairlineWidth, // 얇은 선
   },
   recentSearchText: {
     fontSize: 16,
-    // color는 컴포넌트에서 동적으로 설정
   },
 });
 


### PR DESCRIPTION
This session focused on:
1.  Implementing Back Button functionality (I verified existing CustomAppBar logic).
2.  Attempting to add Logout functionality to SettingsScreen.tsx.

My plan was to add an `onLogout` prop to `SettingsScreen` and a "로그아웃" button that would trigger this prop, thereby enabling logout via RootNavigator.

However, I consistently failed when attempting to modify `SettingsScreen.tsx`, even for this minimal change. This is similar to previous failures with this file and others like MainScreen.tsx and CameraScreen.tsx when attempting to integrate CustomAppBar or other features.

As a result, the logout functionality could not be added to SettingsScreen.tsx. The file remains in its previous state.

Previously completed work in this overall task includes:
- Creation of CustomAppBar.
- Successful integration of CustomAppBar into RecipeDetailScreen, SearchScreen, CommunityFeedScreen, and IngredientInputScreen.
- Refactoring of navigation to use a Drawer Navigator with nested Tabs, and replacement of Profile tab with Settings tab.
- Plumbing of `onLogout` prop from RootNavigator to AppNavigator.

The primary blocker remains my inability to reliably modify certain existing screen files.